### PR TITLE
Add 60 second refresh header to main page

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>{{ metaTitle }}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"> 
+    <meta http-equiv="refresh" content="60">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/css/style.css">
 </head>


### PR DESCRIPTION
Had added a <meta http-equiv="refresh" content="60"> tag to main page to automatically refresh the session grid page every 60 seconds. Change the content value to change refresh rate.