### PR TITLE
Fix session notes link

### DIFF
--- a/views/full_session.handlebars
+++ b/views/full_session.handlebars
@@ -48,7 +48,7 @@ Back to session listing
 {{#if session.sessionnotes }}
 <p>
 <strong>Session notes:</strong>
-<a target="_blank" title="Session notes on Google Docs" href="http://{{ session.sessionnotes }}">{{ session.sessionnotes }}</a>
+<a target="_blank" title="Session notes on Google Docs" href="{{ session.sessionnotes }}">{{ session.sessionnotes }}</a>
 </p>
 {{/if}}
 


### PR DESCRIPTION
Remove adding of https:// to the beginning of  session links, because it's already included in the field on the spreadsheet